### PR TITLE
config check

### DIFF
--- a/pinokio.js
+++ b/pinokio.js
@@ -4,10 +4,12 @@ module.exports = {
   title: "IOPaint",
   description: "Image inpainting tool powered by SOTA AI models. Remove any unwanted object, defect, or even people from your pictures, and replace (powered by stable diffusion) anything in your pictures. https://www.iopaint.com/",
   icon: "icon.jpg",
-  menu: async (kernel, info) => {
+  menu: async (info) => {
     let installing = info.running("install.js")
     let installed = info.exists("app/env")
     let running = info.running("start.js")
+    let runconf = info.running("start-config.js")
+    let config = info.exists("app/config.json")
     if (installing) {
       return [{
         default: true,
@@ -16,8 +18,8 @@ module.exports = {
         href: "install.js",
       }]
     } else if (installed) {
-      if (running) {
-        let local = info.local("start.js")
+      if (runconf && config) {
+        let local = info.local("start-config.js")
         if (local && local.url) {
           return [{
             default: true,
@@ -27,17 +29,69 @@ module.exports = {
           }, {
             icon: 'fa-solid fa-terminal',
             text: "Terminal",
-            href: "start.js",
+            href: "start-config.js",
+          }, {
+            icon: "fa-solid fa-plug",
+            text: "IOPaint Settings",
+            href: "web-config.js",
           }]
         } else {
           return [{
             default: true,
             icon: 'fa-solid fa-terminal',
             text: "Terminal",
-            href: "start.js",
+            href: "start-config.js",
           }]
         }
-      } else {
+      } else if (running) {
+          let local = info.local("start.js")
+          if (local && local.url) {
+            return [{
+              default: true,
+              icon: "fa-solid fa-rocket",
+              text: "Open Web UI",
+              href: local.url,
+            }, {
+              icon: 'fa-solid fa-terminal',
+              text: "Terminal",
+              href: "start.js",
+            }, {
+              icon: "fa-solid fa-plug",
+              text: "IOPaint Settings",
+              href: "web-config.js",
+            }]
+          } else {
+            return [{
+              default: true,
+              icon: 'fa-solid fa-terminal',
+              text: "Terminal",
+              href: "start.js",
+            }]  
+          }
+    } else if (config) {
+      return [{
+        default: true,
+        icon: "fa-solid fa-power-off",
+        text: "Start",
+        href: "start-config.js",
+      }, {
+        icon: "fa-solid fa-plug",
+        text: "IOPaint Settings",
+        href: "web-config.js",
+      }, {
+        icon: "fa-solid fa-plug",
+        text: "Update",
+        href: "update.js",
+      }, {
+        icon: "fa-solid fa-plug",
+        text: "Install",
+        href: "install.js",
+      }, {
+        icon: "fa-regular fa-circle-xmark",
+        text: "Reset",
+        href: "reset.js",
+      }]
+    } else {
         return [{
           default: true,
           icon: "fa-solid fa-power-off",
@@ -60,7 +114,7 @@ module.exports = {
           text: "Reset",
           href: "reset.js",
         }]
-      }
+      }  
     } else {
       return [{
         default: true,

--- a/start-config.js
+++ b/start-config.js
@@ -1,0 +1,35 @@
+module.exports = {
+  daemon: true,
+  run: [
+    {
+      method: "shell.run",
+      params: {
+        venv: "env",                // Edit this to customize the venv folder path
+        env: { },                   // Edit this to customize environment variables (see documentation)
+        path: "app",                // Edit this to customize the path to start the shell from
+        message: [
+          "iopaint start --config config.json",
+        ],
+        on: [{
+          // The regular expression pattern to monitor.
+          // When this pattern occurs in the shell terminal, the shell will return,
+          // and the script will go onto the next step.
+          "event": "/http:\/\/\\S+/",   
+
+          // "done": true will move to the next step while keeping the shell alive.
+          // "kill": true will move to the next step after killing the shell.
+          "done": true
+        }]
+      }
+    },
+    {
+      // This step sets the local variable 'url'.
+      // This local variable will be used in pinokio.js to display the "Open WebUI" tab when the value is set.
+      method: "local.set",
+      params: {
+        // the input.event is the regular expression match object from the previous step
+        url: "{{input.event[0]}}"
+      }
+    }
+  ]
+}

--- a/start.js
+++ b/start.js
@@ -8,7 +8,7 @@ module.exports = {
         env: { },                   // Edit this to customize environment variables (see documentation)
         path: "app",                // Edit this to customize the path to start the shell from
         message: [
-          "iopaint start --config iopaint-config.json",
+          "iopaint start",
         ],
         on: [{
           // The regular expression pattern to monitor.

--- a/torch.js
+++ b/torch.js
@@ -7,7 +7,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}}  --index-url https://download.pytorch.org/whl/cu121"
+        "message": "pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu124"
       }
     },
     // windows amd
@@ -17,7 +17,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "pip install torch-directml torchvision torchaudio"
+        "message": "pip install torch-directml torchvision torchaudio numpy==1.26.4"
       }
     },
     // windows cpu
@@ -27,7 +27,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "pip install torch torchvision torchaudio"
+        "message": "pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu"
       }
     },
     // mac
@@ -47,7 +47,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}}"
+        "message": "pip install torch torchvision torchaudio {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu124"
       }
     },
     // linux rocm (amd)

--- a/web-config.js
+++ b/web-config.js
@@ -8,7 +8,7 @@ module.exports = {
         env: { },                   // Edit this to customize environment variables (see documentation)
         path: "app",                // Edit this to customize the path to start the shell from
         message: [
-          "iopaint start-web-config --config-file iopaint-config.json",
+          "iopaint start-web-config",
         ],
         on: [{
           // The regular expression pattern to monitor.


### PR DESCRIPTION
- Removed the config flag in `start.js`
- Added `start-config.js` containing the config flag
- pinokio.js checks if `config.json` is present and launches IO Paint accordingly with or without the flag
- Settings will be always displayed to point the user to the possibility to set a config file (can be easily missed due to autostart)
- Switched to torch for cuda 12.4
- Added numpy 1.26.4 for windows amd since torch-directml uses numpy 2.x as dependency which causes incompatibility
- Removed the flag for `web-config.js` to use the default file name `config.json` for the config file